### PR TITLE
fix(ci): use FERRFLOW_TOKEN for release push authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.FERRFLOW_TOKEN }}
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Release
         uses: FerrFlow-Org/ferrflow@v0
         env:


### PR DESCRIPTION
## Summary

- Use `FERRFLOW_TOKEN` instead of `GITHUB_TOKEN` for checkout and release push
- Set remote URL with token for git2 authentication
- Pass `FERRFLOW_TOKEN` as both `FERRFLOW_TOKEN` and `GITHUB_TOKEN` env vars

The `GITHUB_TOKEN` cannot push to protected branches. `FERRFLOW_TOKEN` (PAT or App token) has the required permissions and must be added as a bypass actor in the branch ruleset.

## Required setup

- [ ] Add `FERRFLOW_TOKEN` secret to the Fixtures repo (Settings > Secrets)
- [ ] Add the token's actor as bypass in the `main` ruleset (Settings > Rules > main > Bypass list)