### PR TITLE
fix: add workspace marker to prevent parent workspace detection

### DIFF
--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "generate-fixtures"
 version = "0.2.0"


### PR DESCRIPTION
## Summary

- Add empty `[workspace]` table to `generator/Cargo.toml` so Cargo treats it as a standalone package
- Prevents Cargo from walking up to a parent workspace (e.g. when checked out inside FerrFlow's repo via the action)

Fixes FerrFlow-Org/FerrFlow CI fixture tests failing with "current package believes it's in a workspace when it's not"