### PR TITLE
fix: resolve ferrflow binary to absolute path

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 FERRFLOW="${FERRFLOW_BIN:-ferrflow}"
+# Resolve to absolute path if relative
+if [[ "$FERRFLOW" == ./* || "$FERRFLOW" == ../* ]]; then
+    FERRFLOW="$(cd "$(dirname "$FERRFLOW")" && pwd)/$(basename "$FERRFLOW")"
+fi
 GEN_DIR="${1:-${GEN_DIR:-fixtures/generated}}"
 PASSED=0
 FAILED=0


### PR DESCRIPTION
## Summary

- Resolve `FERRFLOW_BIN` to an absolute path at script start
- Fixes test failures when the binary path is relative (e.g. `./target/release/ferrflow`) since `run-tests.sh` does `cd` into each fixture directory before running it