### PR TITLE
feat: migrate fixture definitions from TOML to JSON

### DIFF
--- a/generator/Cargo.lock
+++ b/generator/Cargo.lock
@@ -106,12 +106,13 @@ dependencies = [
 
 [[package]]
 name = "generate-fixtures"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
  "git2",
  "serde",
+ "serde_json",
  "toml",
 ]
 
@@ -284,6 +285,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -481,6 +488,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -823,3 +843,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 git2 = "0.20"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "0.8"
 anyhow = "1"
 chrono = "0.4"

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 // ---------------------------------------------------------------------------
-// TOML definition types
+// Definition types
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
@@ -299,7 +299,7 @@ fn main() -> Result<()> {
 
     let mut entries: Vec<_> = fs::read_dir(&defs_dir)?
         .filter_map(Result::ok)
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "toml"))
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
         .collect();
     entries.sort_by_key(|e| e.path());
 
@@ -359,7 +359,7 @@ fn generate_fixture(def_path: &Path, output_dir: &Path) -> Result<()> {
     let content = fs::read_to_string(def_path)
         .with_context(|| format!("reading {}", def_path.display()))?;
     let def: FixtureDef =
-        toml::from_str(&content).with_context(|| format!("parsing {}", def_path.display()))?;
+        serde_json::from_str(&content).with_context(|| format!("parsing {}", def_path.display()))?;
 
     if def.generate.is_some() {
         generate_bulk(&def, output_dir)


### PR DESCRIPTION
## Summary
- Generator now reads `.json` definitions instead of `.toml`
- Added `serde_json` dependency
- Better suited for complex nested structures (multi-branch, bulk generation)

Closes #23