### PR TITLE
chore: enable skipCi in release commits

### DIFF
--- a/ferrflow.json
+++ b/ferrflow.json
@@ -4,7 +4,7 @@
     "branch": "main",
     "releaseCommitMode": "commit",
     "floatingTags": ["major"],
-    "skipCi": false
+    "skipCi": true
   },
   "package": [
     {


### PR DESCRIPTION
## Summary
- Set `skipCi: true` to append `[skip ci]` to release commits, preventing redundant CI runs