### PR TITLE
feat: add default_branch support and head branch detection fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ echo "running pre-bump"
 '''
 ```
 
+#### Custom default branch
+
+```toml
+[meta]
+name = "my-fixture"
+description = "Repo with master as default branch"
+default_branch = "master"  # defaults to git's init.defaultBranch if omitted
+```
+
 #### Merge commits
 
 ```toml

--- a/fixtures/examples/head-branch-custom.toml
+++ b/fixtures/examples/head-branch-custom.toml
@@ -1,0 +1,31 @@
+[meta]
+name = "head-branch-custom"
+description = "Default branch is 'develop' — ferrflow should auto-detect it"
+default_branch = "develop"
+
+[config]
+content = '''
+{
+  "package": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "versioned_files": [{"path": "version.toml", "format": "toml"}]
+    }
+  ]
+}
+'''
+
+[[packages]]
+name = "myapp"
+path = "."
+initial_version = "1.0.0"
+tag = "v1.0.0"
+
+[[commits]]
+message = "feat: add dashboard"
+files = ["src/dashboard.rs"]
+
+[expect]
+check_contains = ["myapp", "1.1.0"]
+check_not_contains = ["Nothing to release"]

--- a/fixtures/examples/head-branch-main.toml
+++ b/fixtures/examples/head-branch-main.toml
@@ -1,0 +1,30 @@
+[meta]
+name = "head-branch-main"
+description = "Default branch is 'main' — ferrflow should auto-detect it"
+
+[config]
+content = '''
+{
+  "package": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "versioned_files": [{"path": "version.toml", "format": "toml"}]
+    }
+  ]
+}
+'''
+
+[[packages]]
+name = "myapp"
+path = "."
+initial_version = "1.0.0"
+tag = "v1.0.0"
+
+[[commits]]
+message = "feat: add dashboard"
+files = ["src/dashboard.rs"]
+
+[expect]
+check_contains = ["myapp", "1.1.0"]
+check_not_contains = ["Nothing to release"]

--- a/fixtures/examples/head-branch-master.toml
+++ b/fixtures/examples/head-branch-master.toml
@@ -1,0 +1,31 @@
+[meta]
+name = "head-branch-master"
+description = "Default branch is 'master' — ferrflow should auto-detect it"
+default_branch = "master"
+
+[config]
+content = '''
+{
+  "package": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "versioned_files": [{"path": "version.toml", "format": "toml"}]
+    }
+  ]
+}
+'''
+
+[[packages]]
+name = "myapp"
+path = "."
+initial_version = "1.0.0"
+tag = "v1.0.0"
+
+[[commits]]
+message = "feat: add dashboard"
+files = ["src/dashboard.rs"]
+
+[expect]
+check_contains = ["myapp", "1.1.0"]
+check_not_contains = ["Nothing to release"]

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use git2::{FileMode, Oid, Repository, Signature, Time};
+use git2::{FileMode, Oid, Repository, RepositoryInitOptions, Signature, Time};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
@@ -33,6 +33,8 @@ struct Meta {
     #[allow(dead_code)]
     name: String,
     description: String,
+    #[serde(default)]
+    default_branch: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -373,7 +375,7 @@ fn generate_fixture(def_path: &Path, output_dir: &Path) -> Result<()> {
 fn generate_explicit(def: &FixtureDef, output_dir: &Path) -> Result<()> {
     fs::create_dir_all(output_dir)?;
 
-    let repo = Repository::init(output_dir)?;
+    let repo = init_repo(output_dir, def.meta.default_branch.as_deref())?;
     {
         let mut config = repo.config()?;
         config.set_str("user.name", "Test")?;
@@ -469,7 +471,7 @@ fn generate_bulk(def: &FixtureDef, output_dir: &Path) -> Result<()> {
 
     fs::create_dir_all(output_dir)?;
 
-    let repo = Repository::init(output_dir)?;
+    let repo = init_repo(output_dir, def.meta.default_branch.as_deref())?;
     let mut b = BulkRepoBuilder::new();
     let mut rng = Rng::new(gen.seed);
     let now = chrono::Utc::now().timestamp();
@@ -552,6 +554,17 @@ fn generate_bulk(def: &FixtureDef, output_dir: &Path) -> Result<()> {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+fn init_repo(path: &Path, default_branch: Option<&str>) -> Result<Repository> {
+    match default_branch {
+        Some(branch) => {
+            let mut opts = RepositoryInitOptions::new();
+            opts.initial_head(branch);
+            Ok(Repository::init_opts(path, &opts)?)
+        }
+        None => Ok(Repository::init(path)?),
+    }
+}
 
 fn resolve_config_filename(config: &ConfigDef) -> String {
     config.filename.clone().unwrap_or_else(|| {


### PR DESCRIPTION
## Summary
- Add optional `default_branch` field to `[meta]` section, allowing fixtures to specify a custom default branch name (e.g. `master`, `develop`)
- Uses `RepositoryInitOptions::initial_head()` when the field is set, falls back to git default otherwise
- Add three example fixtures covering `main`, `master`, and a custom branch name (`develop`)
- Document the new field in README

Closes #21