### PR TITLE
feat: add pre-release channel fixture definitions

### DIFF
--- a/fixtures/examples/prerelease-breaking.json
+++ b/fixtures/examples/prerelease-breaking.json
@@ -1,0 +1,32 @@
+{
+  "meta": {
+    "name": "prerelease-breaking",
+    "description": "Breaking change on a beta pre-release channel bumps major with beta suffix"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"branches\": [\n      {\n        \"name\": \"main\",\n        \"channel\": \"beta\",\n        \"prereleaseIdentifier\": \"increment\"\n      }\n    ]\n  },\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.0.0-beta.2"
+    }
+  ],
+  "tags": [
+    {
+      "name": "v1.0.0-beta.2",
+      "at_commit": -1
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat!: redesign API surface",
+      "files": ["src/api.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib", "major"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/prerelease-monorepo.json
+++ b/fixtures/examples/prerelease-monorepo.json
@@ -1,0 +1,43 @@
+{
+  "meta": {
+    "name": "prerelease-monorepo",
+    "description": "Monorepo with one package on alpha channel and two stable packages"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"branches\": [\n      {\n        \"name\": \"main\",\n        \"channel\": \"alpha\",\n        \"prereleaseIdentifier\": \"increment\"\n      }\n    ]\n  },\n  \"package\": [\n    {\n      \"name\": \"core\",\n      \"path\": \"core\",\n      \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]\n    },\n    {\n      \"name\": \"cli\",\n      \"path\": \"cli\",\n      \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]\n    },\n    {\n      \"name\": \"web\",\n      \"path\": \"web\",\n      \"versioned_files\": [{\"path\": \"web/version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "core",
+      "path": "core",
+      "initial_version": "1.0.0",
+      "tag": "core@v1.0.0"
+    },
+    {
+      "name": "cli",
+      "path": "cli",
+      "initial_version": "1.0.0",
+      "tag": "cli@v1.0.0"
+    },
+    {
+      "name": "web",
+      "path": "web",
+      "initial_version": "1.0.0",
+      "tag": "web@v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat(core): add new parser",
+      "files": ["core/src/parser.rs"]
+    },
+    {
+      "message": "fix(cli): handle empty args",
+      "files": ["cli/src/main.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["core", "cli"],
+    "check_not_contains": ["Nothing to release", "web"]
+  }
+}

--- a/fixtures/examples/prerelease-promote-stable.json
+++ b/fixtures/examples/prerelease-promote-stable.json
@@ -1,0 +1,32 @@
+{
+  "meta": {
+    "name": "prerelease-promote-stable",
+    "description": "Promoting from rc pre-release to stable removes the pre-release suffix"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"branches\": [\n      {\n        \"name\": \"main\",\n        \"channel\": true\n      }\n    ]\n  },\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "2.0.0-rc.3"
+    }
+  ],
+  "tags": [
+    {
+      "name": "v2.0.0-rc.3",
+      "at_commit": -1
+    }
+  ],
+  "commits": [
+    {
+      "message": "chore: prepare stable release",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib", "2.0.0"],
+    "check_not_contains": ["Nothing to release", "rc"]
+  }
+}

--- a/fixtures/examples/prerelease-sequential.json
+++ b/fixtures/examples/prerelease-sequential.json
@@ -1,0 +1,32 @@
+{
+  "meta": {
+    "name": "prerelease-sequential",
+    "description": "Sequential pre-release identifiers increment correctly from existing alpha tag"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"branches\": [\n      {\n        \"name\": \"main\",\n        \"channel\": \"alpha\",\n        \"prereleaseIdentifier\": \"increment\"\n      }\n    ]\n  },\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.1.0-alpha.0"
+    }
+  ],
+  "tags": [
+    {
+      "name": "v1.1.0-alpha.0",
+      "at_commit": -1
+    }
+  ],
+  "commits": [
+    {
+      "message": "fix: patch on alpha channel",
+      "files": ["src/fix.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib", "alpha.1"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 4 new pre-release fixture definitions:
  - `prerelease-sequential`: incremented alpha identifiers from existing tag
  - `prerelease-promote-stable`: rc to stable promotion
  - `prerelease-monorepo`: mixed channels across packages
  - `prerelease-breaking`: breaking change on beta channel

Closes #2