### PR TITLE
feat: add tag template fixture definitions

### DIFF
--- a/fixtures/examples/tag-template-custom-prefix.json
+++ b/fixtures/examples/tag-template-custom-prefix.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "tag-template-custom-prefix",
+    "description": "Non-standard tag template with custom prefix pattern"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"tag_template\": \"release/{name}/{version}\"\n  },\n  \"package\": [\n    {\n      \"name\": \"api\",\n      \"path\": \"api\",\n      \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "api",
+      "path": "api",
+      "initial_version": "0.5.0",
+      "tag": "release/api/0.5.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "fix(api): handle timeout",
+      "files": ["api/src/handler.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["api", "0.5.1"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/tag-template-mismatch.json
+++ b/fixtures/examples/tag-template-mismatch.json
@@ -1,0 +1,32 @@
+{
+  "meta": {
+    "name": "tag-template-mismatch",
+    "description": "Existing tags use a different format than the configured template"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"tag_template\": \"{name}@v{version}\"\n  },\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.0.0"
+    }
+  ],
+  "tags": [
+    {
+      "name": "v1.0.0",
+      "at_commit": -1
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: add feature",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib"],
+    "check_not_contains": []
+  }
+}

--- a/fixtures/examples/tag-template-name-at-version.json
+++ b/fixtures/examples/tag-template-name-at-version.json
@@ -1,0 +1,33 @@
+{
+  "meta": {
+    "name": "tag-template-name-at-version",
+    "description": "Monorepo tag template using {name}@v{version} pattern"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"tag_template\": \"{name}@v{version}\"\n  },\n  \"package\": [\n    {\n      \"name\": \"core\",\n      \"path\": \"core\",\n      \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]\n    },\n    {\n      \"name\": \"cli\",\n      \"path\": \"cli\",\n      \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "core",
+      "path": "core",
+      "initial_version": "1.0.0",
+      "tag": "core@v1.0.0"
+    },
+    {
+      "name": "cli",
+      "path": "cli",
+      "initial_version": "1.0.0",
+      "tag": "cli@v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat(core): add new feature",
+      "files": ["core/src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["core", "1.1.0"],
+    "check_not_contains": ["Nothing to release", "cli"]
+  }
+}

--- a/fixtures/examples/tag-template-v-only.json
+++ b/fixtures/examples/tag-template-v-only.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "tag-template-v-only",
+    "description": "Single package with standard v{version} tag template"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"tag_template\": \"v{version}\"\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: add dashboard",
+      "files": ["src/dashboard.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 4 tag template fixture definitions:
  - `tag-template-name-at-version`: monorepo `{name}@v{version}` pattern
  - `tag-template-v-only`: standard single-package `v{version}` template
  - `tag-template-custom-prefix`: non-standard `release/{name}/{version}` prefix
  - `tag-template-mismatch`: existing tags in different format than config

Closes #3