### PR TITLE
feat: add floating tags fixture definitions

### DIFF
--- a/fixtures/examples/floating-tags-basic.json
+++ b/fixtures/examples/floating-tags-basic.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "floating-tags-basic",
+    "description": "Floating tag v1 moves to latest minor release within major version"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"floating_tags\": true\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "1.2.0",
+      "tag": "v1.2.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: add new feature",
+      "files": ["src/feature.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.3.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/floating-tags-disabled.json
+++ b/fixtures/examples/floating-tags-disabled.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "floating-tags-disabled",
+    "description": "Floating tags disabled — release happens but no floating tags are created"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"floating_tags\": false\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: add feature",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/floating-tags-major-bump.json
+++ b/fixtures/examples/floating-tags-major-bump.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "floating-tags-major-bump",
+    "description": "Breaking change creates new floating tag v2 while v1 stays on previous release"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"floating_tags\": true\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "1.5.0",
+      "tag": "v1.5.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat!: redesign public API",
+      "files": ["src/api.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "2.0.0", "major"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/floating-tags-monorepo.json
+++ b/fixtures/examples/floating-tags-monorepo.json
@@ -1,0 +1,37 @@
+{
+  "meta": {
+    "name": "floating-tags-monorepo",
+    "description": "Monorepo with per-package floating tags"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"floating_tags\": true,\n    \"tag_template\": \"{name}@v{version}\"\n  },\n  \"package\": [\n    {\n      \"name\": \"core\",\n      \"path\": \"core\",\n      \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]\n    },\n    {\n      \"name\": \"cli\",\n      \"path\": \"cli\",\n      \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "core",
+      "path": "core",
+      "initial_version": "2.0.0",
+      "tag": "core@v2.0.0"
+    },
+    {
+      "name": "cli",
+      "path": "cli",
+      "initial_version": "1.0.0",
+      "tag": "cli@v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat(core): add parser",
+      "files": ["core/src/parser.rs"]
+    },
+    {
+      "message": "fix(cli): handle empty input",
+      "files": ["cli/src/main.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["core", "2.1.0", "cli", "1.0.1"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 4 floating tags fixture definitions:
  - `floating-tags-basic`: floating tag moves on minor bump
  - `floating-tags-major-bump`: breaking change creates new floating tag
  - `floating-tags-disabled`: floating tags off, no floating tags created
  - `floating-tags-monorepo`: per-package floating tags

Closes #4