### PR TITLE
feat: add changelog generation fixture definitions

### DIFF
--- a/fixtures/examples/changelog-breaking-changes.json
+++ b/fixtures/examples/changelog-breaking-changes.json
@@ -1,0 +1,31 @@
+{
+  "meta": {
+    "name": "changelog-breaking-changes",
+    "description": "Breaking changes with feat! and BREAKING CHANGE footer appear in changelog"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}],\n      \"changelog\": \"CHANGELOG.md\"\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat!: redesign config file format",
+      "files": ["src/config.rs"]
+    },
+    {
+      "message": "feat: add validation\n\nBREAKING CHANGE: removed legacy parser",
+      "files": ["src/validate.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib", "2.0.0", "major"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/changelog-monorepo-per-package.json
+++ b/fixtures/examples/changelog-monorepo-per-package.json
@@ -1,0 +1,48 @@
+{
+  "meta": {
+    "name": "changelog-monorepo-per-package",
+    "description": "Monorepo with 3 packages — each gets its own changelog section"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"api\",\n      \"path\": \"api\",\n      \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}],\n      \"changelog\": \"api/CHANGELOG.md\"\n    },\n    {\n      \"name\": \"cli\",\n      \"path\": \"cli\",\n      \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}],\n      \"changelog\": \"cli/CHANGELOG.md\"\n    },\n    {\n      \"name\": \"core\",\n      \"path\": \"core\",\n      \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}],\n      \"changelog\": \"core/CHANGELOG.md\"\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "api",
+      "path": "api",
+      "initial_version": "1.0.0",
+      "tag": "api@v1.0.0"
+    },
+    {
+      "name": "cli",
+      "path": "cli",
+      "initial_version": "1.0.0",
+      "tag": "cli@v1.0.0"
+    },
+    {
+      "name": "core",
+      "path": "core",
+      "initial_version": "1.0.0",
+      "tag": "core@v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat(api): add events endpoint",
+      "files": ["api/src/events.rs"]
+    },
+    {
+      "message": "fix(cli): handle timeout",
+      "files": ["cli/src/main.rs"]
+    },
+    {
+      "message": "feat(core): add parser",
+      "files": ["core/src/parser.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["api", "1.1.0", "cli", "1.0.1", "core", "1.1.0"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 3
+  }
+}

--- a/fixtures/examples/changelog-multi-release.json
+++ b/fixtures/examples/changelog-multi-release.json
@@ -1,0 +1,33 @@
+{
+  "meta": {
+    "name": "changelog-multi-release",
+    "description": "Two rounds of commits with tags — changelog only includes commits since last tag"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}],\n      \"changelog\": \"CHANGELOG.md\"\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: first feature",
+      "files": ["src/first.rs"]
+    }
+  ],
+  "tags": [
+    {
+      "name": "v1.1.0",
+      "at_commit": 0
+    }
+  ],
+  "expect": {
+    "check_contains": ["Nothing to release"],
+    "check_not_contains": []
+  }
+}

--- a/fixtures/examples/changelog-no-releasable.json
+++ b/fixtures/examples/changelog-no-releasable.json
@@ -1,0 +1,31 @@
+{
+  "meta": {
+    "name": "changelog-no-releasable",
+    "description": "Only chore and ci commits — no releasable changes, no changelog entry"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}],\n      \"changelog\": \"CHANGELOG.md\"\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "chore: update dependencies",
+      "files": ["Cargo.lock"]
+    },
+    {
+      "message": "ci: fix workflow",
+      "files": [".github/workflows/ci.yml"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["Nothing to release"],
+    "check_not_contains": ["1.0.1", "1.1.0"]
+  }
+}

--- a/fixtures/examples/changelog-scoped-commits.json
+++ b/fixtures/examples/changelog-scoped-commits.json
@@ -1,0 +1,35 @@
+{
+  "meta": {
+    "name": "changelog-scoped-commits",
+    "description": "Scoped commits are grouped correctly in changelog output"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}],\n      \"changelog\": \"CHANGELOG.md\"\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat(api): add events endpoint",
+      "files": ["src/api.rs"]
+    },
+    {
+      "message": "fix(cli): handle empty input",
+      "files": ["src/cli.rs"]
+    },
+    {
+      "message": "refactor(core): simplify parser",
+      "files": ["src/core.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.1.0", "minor"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 5 changelog fixture definitions:
  - `changelog-breaking-changes`: feat! and BREAKING CHANGE footer
  - `changelog-scoped-commits`: scoped commits grouped correctly
  - `changelog-multi-release`: commits only since last tag
  - `changelog-no-releasable`: chore/ci only, no release
  - `changelog-monorepo-per-package`: per-package changelog sections

Closes #5