### PR TITLE
feat: add hook execution fixture definitions

### DIFF
--- a/fixtures/examples/hooks-env-variables.json
+++ b/fixtures/examples/hooks-env-variables.json
@@ -1,0 +1,30 @@
+{
+  "meta": {
+    "name": "hooks-env-variables",
+    "description": "Hooks receive correct environment variables from FerrFlow"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"hooks\": {\n      \"postBump\": \"./hooks/post-bump.sh\"\n    }\n  },\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "hooks": [
+    { "path": "hooks/post-bump.sh", "content": "#!/usr/bin/env bash\necho \"version=$FERRFLOW_VERSION package=$FERRFLOW_PACKAGE\" >> /tmp/env.log\n" }
+  ],
+  "commits": [
+    {
+      "message": "feat: add feature for env test",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/hooks-execution-order.json
+++ b/fixtures/examples/hooks-execution-order.json
@@ -1,0 +1,34 @@
+{
+  "meta": {
+    "name": "hooks-execution-order",
+    "description": "All lifecycle hooks execute in correct order: preBump, postBump, preCommit, prePublish, postPublish"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"hooks\": {\n      \"preBump\": \"./hooks/pre-bump.sh\",\n      \"postBump\": \"./hooks/post-bump.sh\",\n      \"preCommit\": \"./hooks/pre-commit.sh\",\n      \"prePublish\": \"./hooks/pre-publish.sh\",\n      \"postPublish\": \"./hooks/post-publish.sh\"\n    }\n  },\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "hooks": [
+    { "path": "hooks/pre-bump.sh", "content": "#!/usr/bin/env bash\necho pre-bump >> /tmp/hooks.log\n" },
+    { "path": "hooks/post-bump.sh", "content": "#!/usr/bin/env bash\necho post-bump >> /tmp/hooks.log\n" },
+    { "path": "hooks/pre-commit.sh", "content": "#!/usr/bin/env bash\necho pre-commit >> /tmp/hooks.log\n" },
+    { "path": "hooks/pre-publish.sh", "content": "#!/usr/bin/env bash\necho pre-publish >> /tmp/hooks.log\n" },
+    { "path": "hooks/post-publish.sh", "content": "#!/usr/bin/env bash\necho post-publish >> /tmp/hooks.log\n" }
+  ],
+  "commits": [
+    {
+      "message": "feat: trigger release with hooks",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/hooks-failure-aborts.json
+++ b/fixtures/examples/hooks-failure-aborts.json
@@ -1,0 +1,30 @@
+{
+  "meta": {
+    "name": "hooks-failure-aborts",
+    "description": "A preBump hook that exits non-zero aborts the release"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"hooks\": {\n      \"preBump\": \"./hooks/pre-bump.sh\"\n    }\n  },\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "hooks": [
+    { "path": "hooks/pre-bump.sh", "content": "#!/usr/bin/env bash\nexit 1\n" }
+  ],
+  "commits": [
+    {
+      "message": "feat: should not release due to hook failure",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/hooks-per-package.json
+++ b/fixtures/examples/hooks-per-package.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "name": "hooks-per-package",
+    "description": "Monorepo with per-package hooks running in the correct package context"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"api\",\n      \"path\": \"api\",\n      \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}],\n      \"hooks\": {\n        \"preBump\": \"./hooks/pre-bump.sh\"\n      }\n    },\n    {\n      \"name\": \"cli\",\n      \"path\": \"cli\",\n      \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}],\n      \"hooks\": {\n        \"preBump\": \"./hooks/pre-bump.sh\"\n      }\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "api",
+      "path": "api",
+      "initial_version": "1.0.0",
+      "tag": "api@v1.0.0"
+    },
+    {
+      "name": "cli",
+      "path": "cli",
+      "initial_version": "1.0.0",
+      "tag": "cli@v1.0.0"
+    }
+  ],
+  "hooks": [
+    { "path": "hooks/pre-bump.sh", "content": "#!/usr/bin/env bash\necho \"bumping $FERRFLOW_PACKAGE\" >> /tmp/hooks.log\n" }
+  ],
+  "commits": [
+    {
+      "message": "feat(api): add endpoint",
+      "files": ["api/src/handler.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["api", "1.1.0"],
+    "check_not_contains": ["Nothing to release", "cli"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 4 hook execution fixture definitions:
  - `hooks-execution-order`: all lifecycle hooks in correct order
  - `hooks-failure-aborts`: non-zero exit in preBump aborts release
  - `hooks-per-package`: monorepo per-package hook context
  - `hooks-env-variables`: hooks receive FERRFLOW_VERSION/FERRFLOW_PACKAGE env vars

Closes #6