### PR TITLE
feat: add edge case fixture definitions

### DIFF
--- a/fixtures/examples/edge-duplicate-tags.json
+++ b/fixtures/examples/edge-duplicate-tags.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "name": "edge-duplicate-tags",
+    "description": "Two tags pointing to the same commit — correct resolution without errors"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.0.0"
+    }
+  ],
+  "tags": [
+    {
+      "name": "v1.0.0",
+      "at_commit": -1
+    },
+    {
+      "name": "release-1.0.0",
+      "at_commit": -1
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: add feature after duplicate tags",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/edge-empty-repo.json
+++ b/fixtures/examples/edge-empty-repo.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "name": "edge-empty-repo",
+    "description": "Repo with no commits after initial setup — clean error, no panic"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "0.0.0"
+    }
+  ],
+  "commits": [],
+  "expect": {
+    "check_contains": ["Nothing to release"],
+    "check_not_contains": []
+  }
+}

--- a/fixtures/examples/edge-initial-release.json
+++ b/fixtures/examples/edge-initial-release.json
@@ -1,0 +1,26 @@
+{
+  "meta": {
+    "name": "edge-initial-release",
+    "description": "No tags exist at all — first release ever uses initial version from config"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "0.1.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: initial feature",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/edge-merge-commits.json
+++ b/fixtures/examples/edge-merge-commits.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "name": "edge-merge-commits",
+    "description": "History contains merge commits alongside conventional commits — handled correctly"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: add feature on branch",
+      "files": ["src/feature.rs"]
+    },
+    {
+      "message": "Merge branch 'feature' into main",
+      "files": ["src/merge-marker.rs"],
+      "merge": true
+    },
+    {
+      "message": "fix: post-merge fix",
+      "files": ["src/fix.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/edge-no-versioned-files.json
+++ b/fixtures/examples/edge-no-versioned-files.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "edge-no-versioned-files",
+    "description": "Package with no versioned files — version tracked via tags only"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": []\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: add feature without versioned files",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/edge-orphaned-tags.json
+++ b/fixtures/examples/edge-orphaned-tags.json
@@ -1,0 +1,33 @@
+{
+  "meta": {
+    "name": "edge-orphaned-tags",
+    "description": "Tags that exist but don't match any package path — handled gracefully"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"orphanedTagStrategy\": \"warn\"\n  },\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "tags": [
+    {
+      "name": "unrelated-tag-v2.0.0",
+      "at_commit": -1
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: add feature",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/edge-recover-missed.json
+++ b/fixtures/examples/edge-recover-missed.json
@@ -1,0 +1,35 @@
+{
+  "meta": {
+    "name": "edge-recover-missed",
+    "description": "recoverMissedReleases enabled — gap of multiple unreleased versions handled correctly"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"recoverMissedReleases\": true\n  },\n  \"package\": [\n    {\n      \"name\": \"mylib\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "mylib",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: first missed feature",
+      "files": ["src/first.rs"]
+    },
+    {
+      "message": "feat!: breaking change",
+      "files": ["src/breaking.rs"]
+    },
+    {
+      "message": "fix: patch after breaking",
+      "files": ["src/fix.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["mylib"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 7 edge case fixture definitions:
  - `edge-empty-repo`: no commits, clean error handling
  - `edge-no-versioned-files`: version tracked via tags only
  - `edge-duplicate-tags`: two tags on same commit
  - `edge-orphaned-tags`: unrelated tags handled gracefully
  - `edge-initial-release`: first release with no existing tags
  - `edge-merge-commits`: merge commits in history
  - `edge-recover-missed`: recoverMissedReleases with version gap

Closes #7