### PR TITLE
feat: add release commit mode fixture definitions

### DIFF
--- a/fixtures/examples/release-commit-message-template.json
+++ b/fixtures/examples/release-commit-message-template.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "release-commit-message-template",
+    "description": "Custom release commit message template — verifies the commit message matches"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"releaseCommitMode\": \"commit\",\n    \"releaseCommitMessage\": \"chore(release): bump {name} to {version}\"\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: trigger release with custom commit message",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/fixtures/examples/release-mode-commit.json
+++ b/fixtures/examples/release-mode-commit.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "release-mode-commit",
+    "description": "Release commit mode 'commit' — release commit is created directly"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"releaseCommitMode\": \"commit\"\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "myapp",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: add direct commit release",
+      "files": ["src/lib.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 2 release commit mode fixture definitions:
  - `release-mode-commit`: direct commit mode
  - `release-commit-message-template`: custom commit message template

The other 2 (none, pr) already exist in FerrFlow's test suite.

Closes #9