### PR TITLE
feat: add --help and --version CLI flags

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -369,6 +369,14 @@ fn parse_args(args: &[String]) -> Result<(PathBuf, PathBuf)> {
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
+            "--help" | "-h" => {
+                print_help();
+                std::process::exit(0);
+            }
+            "--version" | "-V" => {
+                println!("generate-fixtures {}", env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
             "--definitions" | "-d" => {
                 i += 1;
                 defs_dir = PathBuf::from(args.get(i).context("missing value for --definitions")?);
@@ -377,12 +385,29 @@ fn parse_args(args: &[String]) -> Result<(PathBuf, PathBuf)> {
                 i += 1;
                 gen_dir = PathBuf::from(args.get(i).context("missing value for --output")?);
             }
-            other => anyhow::bail!("unknown argument: {other}"),
+            other => anyhow::bail!("unknown argument: {other}\n\nRun with --help for usage."),
         }
         i += 1;
     }
 
     Ok((defs_dir, gen_dir))
+}
+
+fn print_help() {
+    println!(
+        "generate-fixtures {}
+Generate git fixture repos from JSON definitions.
+
+USAGE:
+    generate-fixtures [OPTIONS]
+
+OPTIONS:
+    -d, --definitions <DIR>    Path to JSON definitions directory [default: fixtures/definitions]
+    -o, --output <DIR>         Output directory for generated repos [default: fixtures/generated]
+    -h, --help                 Print help information
+    -V, --version              Print version",
+        env!("CARGO_PKG_VERSION")
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `--help` / `-h` flag with usage info listing all available flags
- Adds `--version` / `-V` flag reading version from Cargo.toml
- Unknown args now include a hint to run `--help`

Closes #35