### PR TITLE
test: add unit tests for generator logic

### DIFF
--- a/generator/Cargo.lock
+++ b/generator/Cargo.lock
@@ -90,6 +90,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +129,7 @@ dependencies = [
  "git2",
  "serde",
  "serde_json",
+ "tempfile",
  "toml",
 ]
 
@@ -359,6 +376,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +476,19 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -550,6 +586,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -742,6 +791,15 @@ name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -16,3 +16,6 @@ serde_json = "1"
 toml = "0.8"
 anyhow = "1"
 chrono = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/generator/src/cli.rs
+++ b/generator/src/cli.rs
@@ -32,6 +32,75 @@ pub fn parse_args(args: &[String]) -> Result<(PathBuf, PathBuf)> {
     Ok((defs_dir, gen_dir))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(slice: &[&str]) -> Vec<String> {
+        slice.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn defaults_when_no_args() {
+        let (defs, gen) = parse_args(&args(&["bin"])).unwrap();
+        assert_eq!(defs, PathBuf::from("fixtures/definitions"));
+        assert_eq!(gen, PathBuf::from("fixtures/generated"));
+    }
+
+    #[test]
+    fn long_flags() {
+        let (defs, gen) =
+            parse_args(&args(&["bin", "--definitions", "/tmp/defs", "--output", "/tmp/out"]))
+                .unwrap();
+        assert_eq!(defs, PathBuf::from("/tmp/defs"));
+        assert_eq!(gen, PathBuf::from("/tmp/out"));
+    }
+
+    #[test]
+    fn short_flags() {
+        let (defs, gen) =
+            parse_args(&args(&["bin", "-d", "my/defs", "-o", "my/out"])).unwrap();
+        assert_eq!(defs, PathBuf::from("my/defs"));
+        assert_eq!(gen, PathBuf::from("my/out"));
+    }
+
+    #[test]
+    fn only_definitions_flag() {
+        let (defs, gen) = parse_args(&args(&["bin", "-d", "custom"])).unwrap();
+        assert_eq!(defs, PathBuf::from("custom"));
+        assert_eq!(gen, PathBuf::from("fixtures/generated"));
+    }
+
+    #[test]
+    fn only_output_flag() {
+        let (defs, gen) = parse_args(&args(&["bin", "-o", "custom"])).unwrap();
+        assert_eq!(defs, PathBuf::from("fixtures/definitions"));
+        assert_eq!(gen, PathBuf::from("custom"));
+    }
+
+    #[test]
+    fn missing_definitions_value() {
+        let result = parse_args(&args(&["bin", "--definitions"]));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("missing value"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn missing_output_value() {
+        let result = parse_args(&args(&["bin", "--output"]));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unknown_argument() {
+        let result = parse_args(&args(&["bin", "--foo"]));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("unknown argument"), "unexpected error: {msg}");
+    }
+}
+
 fn print_help() {
     println!(
         "generate-fixtures {}

--- a/generator/src/rng.rs
+++ b/generator/src/rng.rs
@@ -66,3 +66,80 @@ pub fn rand_time(rng: &mut Rng, now: i64) -> Time {
     let offset = days * 86400 + hours * 3600 + mins * 60;
     Time::new(now - offset, 0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_sequence() {
+        let mut a = Rng::new(123);
+        let mut b = Rng::new(123);
+        let vals_a: Vec<usize> = (0..20).map(|_| a.usize(1000)).collect();
+        let vals_b: Vec<usize> = (0..20).map(|_| b.usize(1000)).collect();
+        assert_eq!(vals_a, vals_b);
+    }
+
+    #[test]
+    fn different_seeds_differ() {
+        let mut a = Rng::new(1);
+        let mut b = Rng::new(2);
+        let vals_a: Vec<usize> = (0..10).map(|_| a.usize(1000)).collect();
+        let vals_b: Vec<usize> = (0..10).map(|_| b.usize(1000)).collect();
+        assert_ne!(vals_a, vals_b);
+    }
+
+    #[test]
+    fn usize_within_range() {
+        let mut rng = Rng::new(42);
+        for _ in 0..200 {
+            let v = rng.usize(10);
+            assert!(v < 10, "got {v}, expected < 10");
+        }
+    }
+
+    #[test]
+    fn pick_returns_item_from_slice() {
+        let items = &["a", "b", "c"];
+        let mut rng = Rng::new(99);
+        for _ in 0..50 {
+            let picked = rng.pick(items);
+            assert!(items.contains(&picked));
+        }
+    }
+
+    #[test]
+    fn rand_message_format() {
+        let mut rng = Rng::new(42);
+        let msg = rand_message(&mut rng, "core");
+        // Must match pattern: type(scope)[!]: word word
+        assert!(msg.contains("(core)"), "missing scope in: {msg}");
+        assert!(msg.contains(": "), "missing colon-space in: {msg}");
+
+        let colon_pos = msg.find(": ").unwrap();
+        let prefix = &msg[..colon_pos];
+        // prefix is like "feat(core)" or "fix(core)!"
+        let paren = prefix.find('(').unwrap();
+        let type_part = &prefix[..paren];
+        assert!(
+            COMMIT_TYPES.contains(&type_part),
+            "unknown commit type '{type_part}' in: {msg}"
+        );
+
+        let body = &msg[colon_pos + 2..];
+        let words: Vec<&str> = body.split_whitespace().collect();
+        assert_eq!(words.len(), 2, "expected two words in body, got: {body}");
+        assert!(WORDS_A.contains(&words[0]), "unknown word_a '{}'", words[0]);
+        assert!(WORDS_B.contains(&words[1]), "unknown word_b '{}'", words[1]);
+    }
+
+    #[test]
+    fn rand_time_is_in_the_past() {
+        let mut rng = Rng::new(42);
+        let now = 1_700_000_000i64;
+        for _ in 0..50 {
+            let t = rand_time(&mut rng, now);
+            assert!(t.seconds() <= now);
+        }
+    }
+}

--- a/generator/src/tree.rs
+++ b/generator/src/tree.rs
@@ -113,3 +113,142 @@ impl BulkRepoBuilder {
         Ok(oid)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn init_repo() -> (TempDir, Repository) {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::init(tmp.path()).unwrap();
+        (tmp, repo)
+    }
+
+    #[test]
+    fn insert_blob_flat() {
+        let (_tmp, repo) = init_repo();
+        let blob = repo.blob(b"hello").unwrap();
+
+        let mut root = TreeNode::new();
+        root.insert_blob("file.txt", blob);
+
+        let tree_oid = root.write(&repo).unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        assert!(tree.get_name("file.txt").is_some());
+    }
+
+    #[test]
+    fn insert_blob_nested() {
+        let (_tmp, repo) = init_repo();
+        let blob = repo.blob(b"data").unwrap();
+
+        let mut root = TreeNode::new();
+        root.insert_blob("a/b/c.txt", blob);
+
+        let tree_oid = root.write(&repo).unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+
+        let a_entry = tree.get_name("a").unwrap();
+        let a_tree = repo.find_tree(a_entry.id()).unwrap();
+        let b_entry = a_tree.get_name("b").unwrap();
+        let b_tree = repo.find_tree(b_entry.id()).unwrap();
+        assert!(b_tree.get_name("c.txt").is_some());
+    }
+
+    #[test]
+    fn insert_blob_overwrites_same_path() {
+        let (_tmp, repo) = init_repo();
+        let blob1 = repo.blob(b"v1").unwrap();
+        let blob2 = repo.blob(b"v2").unwrap();
+
+        let mut root = TreeNode::new();
+        root.insert_blob("f.txt", blob1);
+        root.insert_blob("f.txt", blob2);
+
+        let tree_oid = root.write(&repo).unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let entry = tree.get_name("f.txt").unwrap();
+        let obj = repo.find_blob(entry.id()).unwrap();
+        assert_eq!(obj.content(), b"v2");
+    }
+
+    #[test]
+    fn cached_oid_invalidated_on_insert() {
+        let (_tmp, repo) = init_repo();
+        let blob1 = repo.blob(b"first").unwrap();
+        let blob2 = repo.blob(b"second").unwrap();
+
+        let mut root = TreeNode::new();
+        root.insert_blob("a.txt", blob1);
+        let oid1 = root.write(&repo).unwrap();
+
+        root.insert_blob("b.txt", blob2);
+        let oid2 = root.write(&repo).unwrap();
+
+        assert_ne!(oid1, oid2);
+    }
+
+    #[test]
+    #[should_panic(expected = "path conflict")]
+    fn insert_blob_conflicts_with_existing_blob() {
+        let (_tmp, repo) = init_repo();
+        let blob = repo.blob(b"x").unwrap();
+
+        let mut root = TreeNode::new();
+        root.insert_blob("f", blob);
+        // Try to insert a nested path where "f" is already a blob
+        root.insert_blob("f/g.txt", blob);
+    }
+
+    #[test]
+    fn builder_set_file_and_commit() {
+        let (_tmp, repo) = init_repo();
+        let mut builder = BulkRepoBuilder::new();
+        let time = Time::new(1_700_000_000, 0);
+
+        builder.set_file(&repo, "README.md", b"# hello").unwrap();
+        let oid = builder.commit(&repo, None, "initial commit", &time).unwrap();
+
+        let commit = repo.find_commit(oid).unwrap();
+        assert_eq!(commit.message(), Some("initial commit"));
+
+        let tree = commit.tree().unwrap();
+        assert!(tree.get_name("README.md").is_some());
+    }
+
+    #[test]
+    fn builder_append_dummy_accumulates() {
+        let (_tmp, repo) = init_repo();
+        let mut builder = BulkRepoBuilder::new();
+        let time = Time::new(1_700_000_000, 0);
+
+        builder.append_dummy(&repo, "src/main.rs").unwrap();
+        let c1 = builder.commit(&repo, None, "first", &time).unwrap();
+
+        builder.append_dummy(&repo, "src/main.rs").unwrap();
+        let c2 = builder.commit(&repo, Some(c1), "second", &time).unwrap();
+
+        // The two commits should have different trees (file content changed)
+        let t1 = repo.find_commit(c1).unwrap().tree_id();
+        let t2 = repo.find_commit(c2).unwrap().tree_id();
+        assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn builder_commit_chain() {
+        let (_tmp, repo) = init_repo();
+        let mut builder = BulkRepoBuilder::new();
+        let time = Time::new(1_700_000_000, 0);
+
+        builder.set_file(&repo, "f.txt", b"a").unwrap();
+        let c1 = builder.commit(&repo, None, "c1", &time).unwrap();
+
+        builder.set_file(&repo, "f.txt", b"b").unwrap();
+        let c2 = builder.commit(&repo, Some(c1), "c2", &time).unwrap();
+
+        let commit2 = repo.find_commit(c2).unwrap();
+        assert_eq!(commit2.parent_count(), 1);
+        assert_eq!(commit2.parent_id(0).unwrap(), c1);
+    }
+}

--- a/generator/src/types.rs
+++ b/generator/src/types.rs
@@ -137,3 +137,53 @@ pub fn resolve_config_filename(config: &ConfigDef) -> String {
             _ => "ferrflow.json".to_string(),
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(format: &str, filename: Option<&str>) -> ConfigDef {
+        ConfigDef {
+            content: String::new(),
+            format: format.to_string(),
+            filename: filename.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn resolve_default_json() {
+        assert_eq!(resolve_config_filename(&config("json", None)), "ferrflow.json");
+    }
+
+    #[test]
+    fn resolve_default_toml() {
+        assert_eq!(resolve_config_filename(&config("toml", None)), ".ferrflow.toml");
+    }
+
+    #[test]
+    fn resolve_default_json5() {
+        assert_eq!(resolve_config_filename(&config("json5", None)), "ferrflow.json5");
+    }
+
+    #[test]
+    fn resolve_unknown_format_falls_back_to_json() {
+        assert_eq!(resolve_config_filename(&config("yaml", None)), "ferrflow.json");
+    }
+
+    #[test]
+    fn resolve_custom_filename_overrides_format() {
+        assert_eq!(
+            resolve_config_filename(&config("toml", Some("my-config.toml"))),
+            "my-config.toml"
+        );
+    }
+
+    #[test]
+    fn resolve_custom_filename_ignores_format_mismatch() {
+        // Even if format is json, a custom filename wins
+        assert_eq!(
+            resolve_config_filename(&config("json", Some(".ferrflow.toml"))),
+            ".ferrflow.toml"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 28 unit tests across all generator modules:
  - `types.rs` (6 tests): config filename resolution
  - `rng.rs` (6 tests): determinism, range, message format
  - `cli.rs` (8 tests): arg parsing, defaults, error cases
  - `tree.rs` (8 tests): blob insertion, caching, repo builder
- Adds `tempfile` as dev-dependency for tree tests

Closes #36