### PR TITLE
ci: add reusable workflow for fixture validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,68 @@
+name: Validate Fixtures
+
+on:
+  workflow_call:
+    inputs:
+      definitions:
+        description: 'Path to JSON fixture definitions in the caller repo'
+        required: true
+        type: string
+      ferrflow-ref:
+        description: 'Git ref (branch/tag/SHA) to build FerrFlow from'
+        required: false
+        type: string
+        default: 'main'
+      test-script:
+        description: 'Path to the test runner script in the caller repo'
+        required: false
+        type: string
+        default: 'tests/fixtures/run-tests.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Generate & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v4
+
+      - name: Generate fixtures
+        id: fixtures
+        uses: FerrFlow-Org/Fixtures@v0
+        with:
+          definitions: ${{ inputs.definitions }}
+
+      - name: Checkout FerrFlow
+        uses: actions/checkout@v4
+        with:
+          repository: FerrFlow-Org/FerrFlow
+          ref: ${{ inputs.ferrflow-ref }}
+          path: __ferrflow__
+
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - uses: actions/cache@v4
+        with:
+          path: __ferrflow__/target
+          key: ferrflow-${{ runner.os }}-${{ inputs.ferrflow-ref }}-${{ hashFiles('__ferrflow__/Cargo.lock') }}
+
+      - name: Build FerrFlow
+        working-directory: __ferrflow__
+        run: cargo build --release
+
+      - name: Run fixture tests
+        run: |
+          chmod +x "${{ inputs.test-script }}"
+          FERRFLOW_BIN="$PWD/__ferrflow__/target/release/ferrflow" \
+            bash "${{ inputs.test-script }}" "${{ steps.fixtures.outputs.generated-path }}"
+
+      - name: Upload test output on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fixture-test-output
+          path: ${{ steps.fixtures.outputs.generated-path }}
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Adds `validate.yml` reusable workflow callable via `workflow_call`
- Inputs: `definitions` path, `ferrflow-ref` (branch/tag to build from), `test-script` path
- Generates fixtures, builds FerrFlow from the specified ref, runs the test script
- Uploads fixture output as artifact on failure
- FerrFlow's CI can call this with:
  ```yaml
  uses: FerrFlow-Org/Fixtures/.github/workflows/validate.yml@main
  with:
    definitions: tests/fixtures/definitions
  ```

Closes #12