### PR TITLE
refactor(generate): extract hardcoded author identity into constants

### DIFF
--- a/generator/src/generate.rs
+++ b/generator/src/generate.rs
@@ -7,6 +7,9 @@ use crate::rng::{rand_message, rand_time, Rng};
 use crate::tree::BulkRepoBuilder;
 use crate::types::{resolve_config_filename, FixtureDef, SerializableExpect};
 
+pub const AUTHOR_NAME: &str = "Test";
+pub const AUTHOR_EMAIL: &str = "test@test.com";
+
 pub fn generate_fixture(def_path: &Path, output_dir: &Path, verbose: bool) -> Result<()> {
     let content =
         fs::read_to_string(def_path).with_context(|| format!("reading {}", def_path.display()))?;
@@ -43,8 +46,8 @@ fn generate_explicit(def: &FixtureDef, output_dir: &Path, verbose: bool) -> Resu
     let repo = init_repo(output_dir, def.meta.default_branch.as_deref())?;
     {
         let mut config = repo.config()?;
-        config.set_str("user.name", "Test")?;
-        config.set_str("user.email", "test@test.com")?;
+        config.set_str("user.name", AUTHOR_NAME)?;
+        config.set_str("user.email", AUTHOR_EMAIL)?;
     }
 
     if let Some(config) = &def.config {
@@ -208,7 +211,7 @@ fn generate_explicit(def: &FixtureDef, output_dir: &Path, verbose: bool) -> Resu
             index.write()?;
             let tree_id = index.write_tree()?;
             let tree = repo.find_tree(tree_id)?;
-            let sig = Signature::now("Test", "test@test.com")?;
+            let sig = Signature::now(AUTHOR_NAME, AUTHOR_EMAIL)?;
 
             repo.commit(
                 Some("HEAD"),
@@ -348,7 +351,7 @@ fn add_all_and_commit(repo: &Repository, message: &str) -> Result<git2::Oid> {
     let tree_id = index.write_tree()?;
     let tree = repo.find_tree(tree_id)?;
 
-    let sig = Signature::now("Test", "test@test.com")?;
+    let sig = Signature::now(AUTHOR_NAME, AUTHOR_EMAIL)?;
 
     let parents: Vec<git2::Commit> = match repo.head() {
         Ok(head) => vec![head.peel_to_commit()?],
@@ -361,7 +364,7 @@ fn add_all_and_commit(repo: &Repository, message: &str) -> Result<git2::Oid> {
 }
 
 fn create_merge_commit(repo: &Repository, _dir: &Path, message: &str) -> Result<git2::Oid> {
-    let sig = Signature::now("Test", "test@test.com")?;
+    let sig = Signature::now(AUTHOR_NAME, AUTHOR_EMAIL)?;
     let main_commit = repo.head()?.peel_to_commit()?;
 
     let mut index = repo.index()?;

--- a/generator/src/tree.rs
+++ b/generator/src/tree.rs
@@ -2,6 +2,8 @@ use anyhow::{bail, Result};
 use git2::{FileMode, Oid, Repository, Signature, Time};
 use std::collections::HashMap;
 
+use crate::generate::{AUTHOR_EMAIL, AUTHOR_NAME};
+
 pub enum TreeEntry {
     Blob(Oid),
     Tree(TreeNode),
@@ -104,7 +106,7 @@ impl BulkRepoBuilder {
     ) -> Result<Oid> {
         let tree_id = self.root.write(repo)?;
         let tree = repo.find_tree(tree_id)?;
-        let s = Signature::new("Test", "test@test.com", time)?;
+        let s = Signature::new(AUTHOR_NAME, AUTHOR_EMAIL, time)?;
 
         let oid = match parent {
             Some(pid) => {


### PR DESCRIPTION
## Summary
- Extract hardcoded `"Test"` / `"test@test.com"` author identity into `AUTHOR_NAME` and `AUTHOR_EMAIL` constants in `generate.rs`
- Replace all 4 hardcoded occurrences in `generate.rs` and 1 in `tree.rs`

Closes #74