### PR TITLE
chore(ci): bump FerrFlow action to v3 and add renovate config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.FERRFLOW_TOKEN }}
 
       - name: Release
-        uses: FerrFlow-Org/ferrflow@v0
+        uses: FerrFlow-Org/ferrflow@v3
         env:
           FERRFLOW_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "rebaseWhen": "behind-base-branch",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "GitHub Actions"
+    }
+  ]
+}


### PR DESCRIPTION
Fixtures was still on `FerrFlow-Org/ferrflow@v0` and had no renovate config, so it had silently drifted.

- `release.yml`: `@v0` → `@v3`, matching every other org repo.
- `renovate.json`: added with the same shape as MCP / Benchmarks / ferrflow (auto-merge patch/minor, manual review for major, group GHA bumps under "GitHub Actions").