### PR TITLE
chore: add GitHub FUNDING file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: BryanFRD


### PR DESCRIPTION
Aligns with the rest of the FerrFlow-Org repos (`ferrflow`, `FerrFlow-Operator`, `Application`, `MCP`, `Benchmarks`) — Fixtures was the only one missing `.github/FUNDING.yml`. Adds the same `github: BryanFRD` sponsor target.