### PR TITLE
fix(ci): rebrand GHCR + GitHub URLs from ferrflow-org to ferrlabs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.FERRFLOW_TOKEN }}
 
       - name: Release
-        uses: FerrFlow-Org/ferrflow@v3
+        uses: FerrLabs/ferrflow@v3
         env:
           FERRFLOW_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,14 +31,14 @@ jobs:
 
       - name: Generate fixtures
         id: fixtures
-        uses: FerrFlow-Org/Fixtures@v0
+        uses: FerrLabs/Fixtures@v0
         with:
           definitions: ${{ inputs.definitions }}
 
       - name: Checkout FerrFlow
         uses: actions/checkout@v4
         with:
-          repository: FerrFlow-Org/FerrFlow
+          repository: FerrLabs/FerrFlow
           ref: ${{ inputs.ferrflow-ref }}
           path: __ferrflow__
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FerrFlow Fixtures
 
-Reusable GitHub Action and CLI tool for generating git fixture repos from declarative JSON definitions. Used by [FerrFlow](https://github.com/FerrFlow-Org/FerrFlow) for integration tests and [Benchmarks](https://github.com/FerrFlow-Org/Benchmarks) for performance testing.
+Reusable GitHub Action and CLI tool for generating git fixture repos from declarative JSON definitions. Used by [FerrFlow](https://github.com/FerrLabs/FerrFlow) for integration tests and [Benchmarks](https://github.com/FerrLabs/Benchmarks) for performance testing.
 
 Fixtures is a pure generator — it builds repos from JSON definitions but does not run any tests. Each consumer repo (FerrFlow, Benchmarks, etc.) owns its own definitions and test runner.
 
@@ -9,7 +9,7 @@ Fixtures is a pure generator — it builds repos from JSON definitions but does 
 ```yaml
 - name: Generate fixture repos
   id: fixtures
-  uses: FerrFlow-Org/Fixtures@v0
+  uses: FerrLabs/Fixtures@v0
   with:
     definitions: tests/fixtures/definitions
 
@@ -48,7 +48,7 @@ Each `.json` file describes a git repo scenario. Add `$schema` for editor autoco
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/FerrFlow-Org/Fixtures/main/schema/fixture.schema.json",
+  "$schema": "https://raw.githubusercontent.com/FerrLabs/Fixtures/main/schema/fixture.schema.json",
   "meta": {
     "name": "monorepo-two-packages",
     "description": "Two packages both touched in the same commit get independent bumps"
@@ -115,7 +115,7 @@ packages_released = 2
   - `output_order`: strings must appear left-to-right by byte offset, with blank lines between consecutive items. Empty array = skip.
   - `packages_released`: count of packages with version bumps must match. If absent, skip this check.
 
-See [FerrFlow's `run-tests.sh`](https://github.com/FerrFlow-Org/FerrFlow/blob/main/tests/fixtures/run-tests.sh) for a reference implementation.
+See [FerrFlow's `run-tests.sh`](https://github.com/FerrLabs/FerrFlow/blob/main/tests/fixtures/run-tests.sh) for a reference implementation.
 
 ### Bulk generation
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Checkout Fixtures
       uses: actions/checkout@v4
       with:
-        repository: FerrFlow-Org/Fixtures
+        repository: FerrLabs/Fixtures
         path: __fixtures__
 
     - name: Cache generator build

--- a/schema/fixture.schema.json
+++ b/schema/fixture.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/FerrFlow-Org/Fixtures/main/schema/fixture.schema.json",
+  "$id": "https://raw.githubusercontent.com/FerrLabs/Fixtures/main/schema/fixture.schema.json",
   "title": "FerrFlow Fixture Definition",
   "description": "Declarative definition for generating a git fixture repository.",
   "type": "object",


### PR DESCRIPTION
Bulk URL update: `ferrflow-org/` → `ferrlabs/`, `FerrFlow-Org/` → `FerrLabs/`. Skips CHANGELOG and lockfiles. Mirrors [FerrFlow-Cloud#376](https://github.com/FerrLabs/FerrFlow-Cloud/pull/376).