### PR TITLE
ci: bump FerrFlow action v3 to v4, switch to bot OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,21 +3,32 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (do not push tags or releases)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
+    name: Release with FerrFlow
+    # Skip release commits to avoid self-triggering loops.
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.FERRFLOW_TOKEN }}
-
-      - name: Release
-        uses: FerrLabs/ferrflow@v3
-        env:
-          FERRFLOW_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
+      - uses: FerrLabs/FerrFlow@v4
+        id: ferrflow
+        with:
+          dry-run: ${{ inputs.dry_run == true }}
+          bot: true


### PR DESCRIPTION
Fixtures was stuck on `FerrLabs/ferrflow@v3` + `FERRFLOW_TOKEN` secret. Bumps to v4 and switches to the bot OIDC flow (matches every other repo in the org). Also normalizes the action casing to `FerrLabs/FerrFlow`.