### PR TITLE
ci: add shared security-scan + Conventional Commits PR title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,33 @@
+name: PR title
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional:
+    name: Conventional commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            docs
+            chore
+            style
+            test
+            perf
+            ci
+            build
+          requireScope: false
+          subjectPattern: ^[A-Za-z].+$
+          subjectPatternError: |
+            Subject "{subject}" must start with an uppercase or lowercase letter and not be empty.

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,20 @@
+name: Security scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Secrets + CVE
+    uses: FerrLabs/.github/.github/workflows/reusable-security-scan.yml@main
+    secrets: inherit


### PR DESCRIPTION
Pure addition — no existing CI touched. Adds two workflows that consume the org-wide infrastructure landed in [FerrLabs/.github#11](https://github.com/FerrLabs/.github/pull/11).

Refs FerrLabs/.github#14