### PR TITLE
chore: add git hooks (.githooks/)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.githooks/* text eol=lf
+*.sh text eol=lf

--- a/.githooks/install.sh
+++ b/.githooks/install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-commit .githooks/pre-push 2>/dev/null || true
+echo "Git hooks installed (core.hooksPath=.githooks)."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git diff --cached --name-only --diff-filter=ACM | grep -qE '\.rs$'; then
+  exit 0
+fi
+
+cd generator
+echo "==> cargo fmt --check"
+cargo fmt --all -- --check
+echo "==> cargo clippy"
+cargo clippy --all-targets -- -D warnings

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd generator
+echo "==> cargo test"
+cargo test --all-features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Git hooks
+
+Run `./.githooks/install.sh` once after cloning to enable pre-commit / pre-push hooks.
+
+The hooks run from `.githooks/` (set via `core.hooksPath`):
+- `pre-commit` — runs `cargo fmt --check` and `cargo clippy -D warnings` on commits touching Rust files.
+- `pre-push` — runs `cargo test --all-features` from `generator/`.


### PR DESCRIPTION
## Summary
- `.githooks/pre-commit` runs `cargo fmt --check` + `cargo clippy -D warnings` on commits touching Rust files.
- `.githooks/pre-push` runs `cargo test`.
- `.githooks/install.sh` sets `core.hooksPath = .githooks` for one-shot setup.

Why `.githooks/` instead of husky: no Node toolchain in this repo.

## Test plan
- [x] `./.githooks/install.sh` set `core.hooksPath` correctly.
- [x] Pre-commit fired on this commit.
- [x] Pre-push fired clean.