### PR TITLE
chore(ci): drop dependabot.yml — fully on Renovate now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      actions:
-        update-types: ["minor", "patch"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>FerrLabs/.github"]
+}


### PR DESCRIPTION
Migrating fully to Renovate self-hosted (FerrLabs/.github). Keeping dependabot.yml around just produces double-PRs and confuses attribution. Net of `renovate.json` extends the org-wide preset; minimal stub when this repo didn't have one yet (the `configurationFile` already provides all the rules at runtime — this file is just consent + future per-repo overrides if needed).