### PR TITLE
chore(workflows): migrate ubuntu-latest to ferrlabs-k8s

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     name: Release with FerrFlow
     # Skip release commits to avoid self-triggering loops.
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     concurrency:
       group: release-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     permissions:
       # Required for publishing results to the GitHub code scanning dashboard.
       security-events: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build:
     name: Build & Generate
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   validate:
     name: Generate & Test
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - name: Checkout caller repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Migrate every direct `runs-on: ubuntu-latest` to `runs-on: ferrlabs-k8s` (self-hosted Kubernetes runner) to stop burning GitHub Actions billing on private repos.

Matrix entries (`os: ubuntu-latest`) and `if: matrix.os == 'ubuntu-latest'` lines are intentionally preserved where present — they drive cross-compilation OS targets, not runner selection. Lines using `${{ inputs.runner }}` are also untouched (consumers pass `ferrlabs-k8s` already).

After merge, re-run failed CI on existing PRs via `gh run rerun --failed`.
