### PR TITLE
chore(hooks): mirror CI checks in pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,5 +2,15 @@
 set -euo pipefail
 
 cd generator
+
+echo "==> cargo fmt --check"
+cargo fmt --all -- --check
+
+echo "==> cargo clippy"
+cargo clippy -- -D warnings
+
 echo "==> cargo test"
 cargo test --all-features
+
+echo "==> cargo build --release"
+cargo build --release


### PR DESCRIPTION
## Summary

Promotes `.githooks/pre-push` from cargo-test-only to the full mirror of `.github/workflows/test.yml`'s `build` job.

`.githooks/pre-push` now runs (in `generator/`):
- `cargo fmt --all -- --check` (mirrors 'Check formatting')
- `cargo clippy -- -D warnings` (mirrors 'Clippy')
- `cargo test --all-features` (mirrors 'Run tests')
- `cargo build --release` (mirrors 'Build generator')

To activate: run `bash .githooks/install.sh` once.

## Test plan
- [ ] All four steps pass on a clean checkout
- [ ] `bash .githooks/install.sh` then `git push --dry-run` does not crash