### PR TITLE
chore: audit batch (clippy fix + SHA-pin actions)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Clippy
         working-directory: generator
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Run tests
         working-directory: generator

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Fixtures is a pure generator — it builds repos from JSON definitions but does 
 ```yaml
 - name: Generate fixture repos
   id: fixtures
-  uses: FerrLabs/Fixtures@v0
+  uses: FerrLabs/Fixtures@v1 # or pin to a commit SHA, e.g. FerrLabs/Fixtures@8a78f82cc8f5df76c4f5f71a7a0ced47e6d82253
   with:
     definitions: tests/fixtures/definitions
 

--- a/action.yml
+++ b/action.yml
@@ -23,19 +23,19 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Fixtures
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: FerrLabs/Fixtures
         path: __fixtures__
 
     - name: Cache generator build
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: __fixtures__/generator/target
         key: fixtures-generator-${{ runner.os }}-${{ hashFiles('__fixtures__/generator/Cargo.lock', '__fixtures__/generator/Cargo.toml', '__fixtures__/generator/src/**') }}
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
     - name: Build generator
       shell: bash

--- a/generator/src/cli.rs
+++ b/generator/src/cli.rs
@@ -60,6 +60,25 @@ pub fn parse_args(args: &[String]) -> Result<Mode> {
     }
 }
 
+fn print_help() {
+    println!(
+        "generate-fixtures {}
+Generate git fixture repos from JSON definitions.
+
+USAGE:
+    generate-fixtures [OPTIONS]
+
+OPTIONS:
+    -d, --definitions <DIR>    Path to JSON definitions directory [default: fixtures/definitions]
+    -o, --output <DIR>         Output directory for generated repos [default: fixtures/generated]
+        --validate             Validate definitions without generating repos
+    -v, --verbose              Print detailed output during generation
+    -h, --help                 Print help information
+    -V, --version              Print version",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -209,23 +228,4 @@ mod tests {
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("unknown argument"), "unexpected error: {msg}");
     }
-}
-
-fn print_help() {
-    println!(
-        "generate-fixtures {}
-Generate git fixture repos from JSON definitions.
-
-USAGE:
-    generate-fixtures [OPTIONS]
-
-OPTIONS:
-    -d, --definitions <DIR>    Path to JSON definitions directory [default: fixtures/definitions]
-    -o, --output <DIR>         Output directory for generated repos [default: fixtures/generated]
-        --validate             Validate definitions without generating repos
-    -v, --verbose              Print detailed output during generation
-    -h, --help                 Print help information
-    -V, --version              Print version",
-        env!("CARGO_PKG_VERSION")
-    );
 }


### PR DESCRIPTION
Closes #111
Closes #112
Closes #110 (already landed on main via #105 — verifying)

## Changes

- Move `print_help` before the test module in `generator/src/cli.rs` to satisfy `clippy::items_after_test_module`.
- Bump CI clippy to `cargo clippy --all-targets -- -D warnings` so the lint actually runs against test code.
- Pin `actions/checkout`, `actions/cache`, and `dtolnay/rust-toolchain` in `action.yml` to commit SHAs, with the floating ref preserved as a trailing comment for readability.
- Update README install snippet from `FerrLabs/Fixtures@v0` to `@v1` and show a SHA-pinning example for downstream consumers.

## Verification

```
cargo build && cargo clippy --all-targets -- -D warnings && cargo test
```

All green locally (60 tests pass).