### PR TITLE
chore(ci): use ubuntu-latest on public repos (free GitHub runners)

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     name: Release with FerrFlow
     # Skip release commits to avoid self-triggering loops.
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     concurrency:
       group: release-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     permissions:
       # Required for publishing results to the GitHub code scanning dashboard.
       security-events: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build:
     name: Build & Generate
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   validate:
     name: Generate & Test
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout caller repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Switch GitHub Actions workflows back from the self-hosted `ferrlabs-k8s` runner pool to GitHub's hosted `ubuntu-latest`. The runner migration was over-applied to public OSS repos — those should stay on GitHub-hosted runners.

Rationale:
- Public repos get unlimited free minutes on GitHub-hosted runners
- Stop burning self-hosted capacity for OSS workloads
- No infra dependency for OSS contributors / community PRs
- Match the standard GitHub-free-on-public model

The composite action (`action.yml`) inherits its runner from the caller and is unchanged.