### PR TITLE
chore(ci): bump FerrLabs/FerrFlow action to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: FerrLabs/FerrFlow@v4
+      - uses: FerrLabs/FerrFlow@v5
         id: ferrflow
         with:
           dry-run: ${{ inputs.dry_run == true }}


### PR DESCRIPTION
## Summary
- Bump `FerrLabs/FerrFlow@v4` → `@v5` in `release.yml`.

## Why
FerrFlow v5.0.0 released (2026-05-21). Only breaking change is internal — replaces URL token injection with the git credential helper protocol. The Action's YAML surface is unchanged.

## Test plan
- [ ] CI green