### PR TITLE
ci: use the reusable FerrFlow release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run (do not push tags or releases)'
+        description: 'Dry run (no tag, no release)'
         type: boolean
         default: false
 
@@ -14,21 +14,13 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
-    name: Release with FerrFlow
-    # Skip release commits to avoid self-triggering loops.
-    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ubuntu-latest
-    concurrency:
-      group: release-${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: false
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: FerrLabs/FerrFlow@v5
-        id: ferrflow
-        with:
-          dry-run: ${{ inputs.dry_run == true }}
-          bot: true
+    uses: FerrLabs/.github/.github/workflows/reusable-ferrflow-release.yml@main
+    with:
+      dry-run: ${{ inputs.dry_run || false }}
+    secrets: inherit


### PR DESCRIPTION
Thin caller of `reusable-ferrflow-release.yml`.\n\nCloses 123