### PR TITLE
perf(generator): parallelize per-definition generation with rayon

### DIFF
--- a/generator/Cargo.lock
+++ b/generator/Cargo.lock
@@ -73,6 +73,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +107,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -127,6 +158,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "git2",
+ "rayon",
  "serde",
  "serde_json",
  "tempfile",
@@ -476,6 +508,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rustix"

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1"
 toml = "1.0"
 anyhow = "1"
 chrono = "0.4"
+rayon = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -6,7 +6,9 @@ mod types;
 mod validate;
 
 use anyhow::Result;
+use rayon::prelude::*;
 use std::fs;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -42,12 +44,18 @@ fn main() -> Result<()> {
             entries.sort_by_key(|e| e.path());
 
             let total = entries.len();
-            let mut ok = 0;
-
-            for entry in &entries {
+            // Each fixture definition produces an independent output
+            // directory under gen_dir/<name>, so we can fan out across
+            // CPU cores. Rayon's default global pool sizes itself to
+            // the host (one thread per logical core), which on a CI
+            // runner with ~6 fixtures cuts wall-time roughly in half.
+            // git2 is safe to use concurrently as long as each thread
+            // builds its own Repository handle, which is exactly what
+            // generate_fixture does.
+            let ok = AtomicUsize::new(0);
+            entries.par_iter().for_each(|entry| {
                 let path = entry.path();
                 let name = path.file_stem().unwrap().to_string_lossy().to_string();
-
                 let start = std::time::Instant::now();
                 match generate::generate_fixture(&path, &gen_dir.join(&name), verbose) {
                     Ok(()) => {
@@ -57,14 +65,15 @@ fn main() -> Result<()> {
                         } else {
                             println!("  ok  {name}");
                         }
-                        ok += 1;
+                        ok.fetch_add(1, Ordering::Relaxed);
                     }
                     Err(e) => {
                         eprintln!("  ERR {name}: {e}");
                     }
                 }
-            }
+            });
 
+            let ok = ok.load(Ordering::Relaxed);
             println!("\n{ok}/{total} fixtures generated");
             if ok < total {
                 std::process::exit(1);


### PR DESCRIPTION
Each fixture definition produces an independent output directory under \`gen_dir/<name>/\`, so the per-definition loop is embarrassingly parallel. Switched to \`rayon::par_iter\` over the sorted definition list. On a typical CI runner with 4–8 cores and ~6 fixtures the wall-time roughly halves; the FerrFlow benchmark suite covers 6 definitions (mono-small/medium/large/50-5k/100-1k/single), so the speedup is tangible at every CI run.

## Concurrency safety

- Each call to \`generate_fixture\` builds its own \`git2::Repository\` handle and its own output dir, so there's no cross-thread shared mutable state. git2 itself is thread-safe across separate Repository instances.
- The `ok` counter became an \`AtomicUsize\` since rayon's \`for_each\` borrows immutably.
- Output ordering is no longer strictly alphabetical — verbose output interleaves across threads. The final \`<ok>/<total> fixtures generated\` line still summarizes correctly.

## Tests

\`cargo test --release\` → 60 passed. Local smoke run against the FerrFlow definitions (6 definitions, including mono-large = 10 000 commits) completed end-to-end.