### PR TITLE
fix(action): correct author from FerrFlow-Org to FerrLabs after org rename

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'FerrFlow Fixtures'
 description: 'Generate git fixture repos from declarative JSON definitions'
-author: 'FerrFlow-Org'
+author: 'FerrLabs'
 branding:
   icon: 'box'
   color: 'orange'


### PR DESCRIPTION
\`action.yml\` still listed \`author: 'FerrFlow-Org'\` from before the GitHub org was renamed to \`FerrLabs\`. The metadata is harmless functionally but inconsistent with every other repo in the workspace (\`FerrFlow\`, \`Benchmarks\`, etc. all use \`FerrLabs\`) and surfaces on the GitHub Marketplace listing for the action.

One-line fix; no behaviour change.