### PR TITLE
fix(generator): make graph mode exercise the dependency cascade

### DIFF
--- a/generator/src/generate.rs
+++ b/generator/src/generate.rs
@@ -288,7 +288,7 @@ fn generate_bulk(def: &FixtureDef, output_dir: &Path, verbose: bool) -> Result<(
 
         let mut parent = oid;
         for i in 1..=commit_count {
-            let idx = if gen.graph && rng.usize(10) < 4 {
+            let idx = if gen.graph {
                 rng.usize(core_count)
             } else {
                 rng.usize(pkg_count)
@@ -367,7 +367,9 @@ fn build_dependency_edges(pkg_count: usize, core_count: usize, rng: &mut Rng) ->
 }
 
 /// Render a ferrflow config wiring each package to its package.json and emitting
-/// `dependsOn` edges for packages that have dependencies.
+/// `dependsOn` edges for packages that have dependencies. `recoverMissedReleases`
+/// is on so that every package with commits since its tag is considered (not just
+/// the one touched by HEAD), which is what lets the dependency cascade fire.
 fn graph_config(packages: &[String], deps: &[Vec<usize>]) -> String {
     let entries: Vec<String> = packages
         .iter()
@@ -385,7 +387,10 @@ fn graph_config(packages: &[String], deps: &[Vec<usize>]) -> String {
             entry
         })
         .collect();
-    format!("{{\"package\":[{}]}}", entries.join(","))
+    format!(
+        "{{\"workspace\":{{\"recoverMissedReleases\":true}},\"package\":[{}]}}",
+        entries.join(",")
+    )
 }
 
 fn init_repo(path: &Path, default_branch: Option<&str>) -> Result<Repository> {
@@ -796,6 +801,7 @@ mod tests {
             config.contains("\"dependsOn\""),
             "config lacks edges: {config}"
         );
+        assert!(config.contains("\"recoverMissedReleases\":true"));
         assert!(config.contains("pkg-001"));
         assert!(config.contains("pkg-010"));
         assert!(out.join("packages/pkg-001/package.json").exists());


### PR DESCRIPTION
Closes #138. Follow-up to #137 (dependency-graph mode) for FerrLabs/FerrFlow#630.

As first merged, `graph` mode didn't actually produce a cascade on a bulk fixture:
- commits were spread across **all** packages (leaves included), so leaves released on their own direct commits rather than via the graph;
- the emitted config lacked `recoverMissedReleases`, so ferrflow (whose `check` is driven by HEAD's changed files) only considered the single HEAD-touched package.

Two changes:
- **Commits target core packages only** — leaves stay untouched, so they can only move via the cascade.
- **`graph_config` emits `workspace.recoverMissedReleases: true`** — every package with commits since its tag is considered, not just the HEAD one.

**Verified end-to-end** (50 packages, 300 commits): `ferrflow check` → **50 released = 10 cores (direct commits) + 40 leaves (pure cascade, 0 direct commits)**. That's the graph/topological work #630 wants to benchmark. Generator suite green (62), clippy + fmt clean.