### PR TITLE
feat(generator): repack and write the commit-graph after generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ cd generator && cargo build --release
   --output /path/to/output
 ```
 
+Generated repos are repacked and get a commit-graph after generation, so they ship in the shape a real clone has instead of thousands of loose objects — consumers that benchmark or test against them measure a realistic object store. This shells out to `git`; pass `--no-pack` to skip it where no git binary is available (the repos then stay fully loose).
+
 ## Fixture definition format
 
 Each `.json` file describes a git repo scenario. Add `$schema` for editor autocomplete and validation:

--- a/generator/src/cli.rs
+++ b/generator/src/cli.rs
@@ -7,6 +7,7 @@ pub enum Mode {
         defs_dir: PathBuf,
         gen_dir: PathBuf,
         verbose: bool,
+        pack: bool,
     },
     Validate {
         defs_dir: PathBuf,
@@ -18,6 +19,7 @@ pub fn parse_args(args: &[String]) -> Result<Mode> {
     let mut gen_dir = PathBuf::from("fixtures/generated");
     let mut validate = false;
     let mut verbose = false;
+    let mut pack = true;
 
     let mut i = 1;
     while i < args.len() {
@@ -44,6 +46,9 @@ pub fn parse_args(args: &[String]) -> Result<Mode> {
             "--verbose" | "-v" => {
                 verbose = true;
             }
+            "--no-pack" => {
+                pack = false;
+            }
             other => anyhow::bail!("unknown argument: {other}\n\nRun with --help for usage."),
         }
         i += 1;
@@ -56,6 +61,7 @@ pub fn parse_args(args: &[String]) -> Result<Mode> {
             defs_dir,
             gen_dir,
             verbose,
+            pack,
         })
     }
 }
@@ -72,6 +78,8 @@ OPTIONS:
     -d, --definitions <DIR>    Path to JSON definitions directory [default: fixtures/definitions]
     -o, --output <DIR>         Output directory for generated repos [default: fixtures/generated]
         --validate             Validate definitions without generating repos
+        --no-pack              Leave generated repos loose instead of repacking
+                               and writing a commit-graph (requires no git binary)
     -v, --verbose              Print detailed output during generation
     -h, --help                 Print help information
     -V, --version              Print version",
@@ -95,6 +103,7 @@ mod tests {
                 defs_dir,
                 gen_dir,
                 verbose,
+                pack: _,
             } => {
                 assert_eq!(defs_dir, PathBuf::from("fixtures/definitions"));
                 assert_eq!(gen_dir, PathBuf::from("fixtures/generated"));
@@ -227,5 +236,23 @@ mod tests {
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("unknown argument"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn pack_is_the_default() {
+        let mode = parse_args(&args(&["gen"])).unwrap();
+        match mode {
+            Mode::Generate { pack, .. } => assert!(pack),
+            _ => panic!("expected generate mode"),
+        }
+    }
+
+    #[test]
+    fn no_pack_flag_disables_packing() {
+        let mode = parse_args(&args(&["gen", "--no-pack"])).unwrap();
+        match mode {
+            Mode::Generate { pack, .. } => assert!(!pack),
+            _ => panic!("expected generate mode"),
+        }
     }
 }

--- a/generator/src/generate.rs
+++ b/generator/src/generate.rs
@@ -10,7 +10,12 @@ use crate::types::{resolve_config_filename, FixtureDef, SerializableExpect};
 pub const AUTHOR_NAME: &str = "Test";
 pub const AUTHOR_EMAIL: &str = "test@test.com";
 
-pub fn generate_fixture(def_path: &Path, output_dir: &Path, verbose: bool) -> Result<()> {
+pub fn generate_fixture(
+    def_path: &Path,
+    output_dir: &Path,
+    verbose: bool,
+    pack: bool,
+) -> Result<()> {
     let content =
         fs::read_to_string(def_path).with_context(|| format!("reading {}", def_path.display()))?;
     let def: FixtureDef = serde_json::from_str(&content)
@@ -33,10 +38,51 @@ pub fn generate_fixture(def_path: &Path, output_dir: &Path, verbose: bool) -> Re
     }
 
     if def.generate.is_some() {
-        generate_bulk(&def, output_dir, verbose)
+        generate_bulk(&def, output_dir, verbose)?;
     } else {
-        generate_explicit(&def, output_dir, verbose)
+        generate_explicit(&def, output_dir, verbose)?;
     }
+
+    if pack {
+        pack_repo(output_dir)?;
+    }
+    Ok(())
+}
+
+// Committing object-by-object through libgit2 leaves the repo fully loose —
+// mono-large ships 40k loose objects and no commit-graph, a shape a real
+// checkout can never have (a clone transfers a pack by definition). Consumers
+// then benchmark and test against a worst case no user hits. Repack + write
+// the commit-graph so the fixture leaves here clone-shaped. libgit2 can build
+// neither a full pack nor a commit-graph, hence the shell-out; failure is a
+// hard error rather than a silent fall-through to the loose shape — pass
+// --no-pack to opt out where git is unavailable.
+fn pack_repo(dir: &Path) -> Result<()> {
+    let run = |args: &[&str]| -> Result<()> {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .with_context(|| {
+                format!(
+                    "spawning git to pack {} — install git or pass --no-pack",
+                    dir.display()
+                )
+            })?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {} failed in {}: {}",
+                args.join(" "),
+                dir.display(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Ok(())
+    };
+    run(&["repack", "-a", "-d", "-q"])?;
+    run(&["commit-graph", "write", "--reachable"])?;
+    Ok(())
 }
 
 /// Generate a fixture from explicit [[commits]] definitions.
@@ -484,6 +530,20 @@ mod tests {
         path
     }
 
+    fn loose_object_count(repo_dir: &Path) -> usize {
+        let objects = repo_dir.join(".git").join("objects");
+        fs::read_dir(&objects)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                let name = e.file_name();
+                let name = name.to_string_lossy();
+                name.len() == 2 && name.chars().all(|c| c.is_ascii_hexdigit())
+            })
+            .map(|d| fs::read_dir(d.path()).unwrap().count())
+            .sum()
+    }
+
     fn count_commits(repo: &Repository) -> usize {
         let mut revwalk = repo.revwalk().unwrap();
         revwalk.push_head().unwrap();
@@ -514,7 +574,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let repo = Repository::open(&out).unwrap();
         assert!(repo.head().is_ok());
@@ -531,7 +591,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let repo = Repository::open(&out).unwrap();
         // 3 explicit commits + 1 initial setup = 4
@@ -549,7 +609,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let repo = Repository::open(&out).unwrap();
         let tags = get_tags(&repo);
@@ -568,7 +628,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let config_path = out.join("ferrflow.json");
         assert!(config_path.exists());
@@ -587,7 +647,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         assert!(out.join(".ferrflow.toml").exists());
     }
@@ -603,7 +663,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let expect_path = out.join(".expect.toml");
         assert!(expect_path.exists());
@@ -624,7 +684,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let hook_path = out.join("hooks/pre-bump.sh");
         assert!(hook_path.exists());
@@ -643,7 +703,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let repo = Repository::open(&out).unwrap();
         let branch = repo.find_branch("develop", git2::BranchType::Local);
@@ -661,7 +721,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let repo = Repository::open(&out).unwrap();
         let head = repo.head().unwrap().peel_to_commit().unwrap();
@@ -680,7 +740,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let repo = Repository::open(&out).unwrap();
         // 10 commits + 1 initial = 11
@@ -701,7 +761,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let repo = Repository::open(&out).unwrap();
         // 5 commits + 1 initial = 6
@@ -724,7 +784,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let repo = Repository::open(&out).unwrap();
         let head = repo.head().unwrap();
@@ -738,7 +798,7 @@ mod tests {
         let def_path = write_def(def_dir.path(), "bad", "not json");
 
         let out = tmp.path().join("bad");
-        let result = generate_fixture(&def_path, &out, false);
+        let result = generate_fixture(&def_path, &out, false, false);
         assert!(result.is_err());
     }
 
@@ -753,7 +813,7 @@ mod tests {
         );
 
         let out = tmp.path().join("test");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let repo = Repository::open(&out).unwrap();
         let head = repo.head().unwrap().peel_to_commit().unwrap();
@@ -794,7 +854,7 @@ mod tests {
         );
 
         let out = tmp.path().join("graph");
-        generate_fixture(&def_path, &out, false).unwrap();
+        generate_fixture(&def_path, &out, false, false).unwrap();
 
         let config = fs::read_to_string(out.join("ferrflow.json")).unwrap();
         assert!(
@@ -805,5 +865,50 @@ mod tests {
         assert!(config.contains("pkg-001"));
         assert!(config.contains("pkg-010"));
         assert!(out.join("packages/pkg-001/package.json").exists());
+    }
+
+    // The reason pack exists: a fixture full of loose objects is a repo shape
+    // a real clone can never have, and consumers benchmark against it.
+    #[test]
+    fn pack_leaves_no_loose_objects_and_writes_the_commit_graph() {
+        let tmp = TempDir::new().unwrap();
+        let def_path = write_def(
+            tmp.path(),
+            "packed",
+            r#"{"meta":{"name":"packed","description":"packed","default_branch":"main"},"generate":{"packages":2,"commits":30}}"#,
+        );
+        let out = tmp.path().join("packed");
+        generate_fixture(&def_path, &out, false, true).unwrap();
+
+        assert_eq!(
+            loose_object_count(&out),
+            0,
+            "a packed fixture must ship no loose objects"
+        );
+        assert!(
+            out.join(".git")
+                .join("objects")
+                .join("info")
+                .join("commit-graph")
+                .exists(),
+            "commit-graph must be written"
+        );
+
+        let repo = Repository::open(&out).unwrap();
+        assert_eq!(count_commits(&repo), 31, "packing must not lose history");
+        assert!(!get_tags(&repo).is_empty(), "packing must not lose tags");
+    }
+
+    #[test]
+    fn no_pack_keeps_the_loose_shape() {
+        let tmp = TempDir::new().unwrap();
+        let def_path = write_def(
+            tmp.path(),
+            "loose",
+            r#"{"meta":{"name":"loose","description":"loose","default_branch":"main"},"generate":{"packages":1,"commits":5}}"#,
+        );
+        let out = tmp.path().join("loose");
+        generate_fixture(&def_path, &out, false, false).unwrap();
+        assert!(loose_object_count(&out) > 0);
     }
 }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -27,6 +27,7 @@ fn main() -> Result<()> {
             defs_dir,
             gen_dir,
             verbose,
+            pack,
         } => {
             if !defs_dir.exists() {
                 anyhow::bail!("{} not found.", defs_dir.display());
@@ -57,7 +58,7 @@ fn main() -> Result<()> {
                 let path = entry.path();
                 let name = path.file_stem().unwrap().to_string_lossy().to_string();
                 let start = std::time::Instant::now();
-                match generate::generate_fixture(&path, &gen_dir.join(&name), verbose) {
+                match generate::generate_fixture(&path, &gen_dir.join(&name), verbose, pack) {
                     Ok(()) => {
                         if verbose {
                             let elapsed = start.elapsed();


### PR DESCRIPTION
Closes #143.

The generator commits object-by-object through libgit2 and never packs, so every fixture ships fully loose — `mono-large` as consumed by the benchmark carries **40 470 loose objects, no pack, no commit-graph**. That is a repo shape a real checkout can never have (a clone transfers a pack by definition), and it taxes the tools unequally: history-reading tools pay per-object I/O 100× over, tools that never read history pay nothing. Measured impact from the issue: `ferrflow check` on `mono-large` goes **30 018 ms loose → 106 ms packed** on the same machine; `complex` — the perf-page cell where ferrflow currently trails commit-and-tag-version — goes 566 ms → 54 ms.

After generation, each fixture now gets `git repack -a -d -q` plus `git commit-graph write --reachable`, so it leaves the generator clone-shaped. libgit2 can build neither a full pack nor a commit-graph, hence the shell-out.

**Failure is a hard error, not a fall-through.** If git is missing or the repack fails, generation fails with a message pointing at `--no-pack` — silently continuing loose would put the benchmark right back on the dishonest shape with nothing surfacing it, which is the exact failure mode (silent SKIP) that hid the semantic-release breakage for weeks. `--no-pack` opts out explicitly for environments without a git binary; the GitHub Action always has one and packs by default, no action changes needed.

Verified end to end with the real `complex` bench definition through the CLI: `count: 0` loose / `in-pack: 1347`, commit-graph present, and `ferrflow check` reads the packed fixture in 58 ms (vs 566 ms loose) — packing loses no history, tags, or worktree.

Tests: the packed fixture asserts zero loose objects, commit-graph present, and unchanged commit/tag counts (packing must not lose history); `--no-pack` keeps the loose shape; CLI parsing covers the default and the flag. Existing generation tests run with `pack: false` — they test generation, not packing, and stay independent of the git binary. 66 tests green, clippy `-D warnings` clean.

**Consumer note:** FerrLabs/FerrFlow pins this action by SHA in two places (test fixtures + bench fixtures) and Benchmarks pins it internally for the non-sharded path — a re-pin follows once this releases. Expect the perf-page numbers to shift substantially and honestly when it lands: the whole point.
