### PR TITLE
ci(pr-title): call the shared reusable workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,40 +1,17 @@
 name: PR title
 
+# `pull_request_target` est délibéré et sûr ici : le job appelé ne fait aucun
+# `checkout`, n'exécute donc rien qui vienne de la PR, et ne lit que le titre
+# dans la charge utile de l'événement. C'est aussi ce qui empêche une PR de fork
+# d'affaiblir sa propre validation en modifiant ce fichier, ce que
+# `pull_request` autoriserait.
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  pull-requests: read
-
 jobs:
-  conventional:
-    name: Conventional commits
-    # Un push sur la branche de la PR ne peut pas changer son titre : revalider
-    # sur `synchronize` recalcule la meme reponse, et Renovate rebase en
-    # permanence. Le job est saute plutot que le declencheur retire : le
-    # workflow produit quand meme un check run sur le nouveau SHA de tete, ce
-    # dont un status check requis a besoin, et un job saute n'occupe aucun
-    # runner. Voir FerrLabs/.github#252.
-    if: github.event.action != 'synchronize'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            refactor
-            docs
-            chore
-            style
-            test
-            perf
-            ci
-            build
-          requireScope: false
-          subjectPattern: ^[A-Za-z].+$
-          subjectPatternError: |
-            Subject "{subject}" must start with an uppercase or lowercase letter and not be empty.
+  title:
+    name: PR title
+    uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@c0bc74da89ab88a5a5f138d94d8ac105536b2f5e # main
+    with:
+      runner: ubuntu-latest


### PR DESCRIPTION
Refs FerrLabs/.github#252

Pilot for the migration from a per-repo copy of the title check to the shared reusable added in FerrLabs/.github#255.

The whole file is now:

```yaml
jobs:
  title:
    name: PR title
    uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@c0bc74d # main
    with:
      runner: ubuntu-latest
```

`runner: ubuntu-latest` because this repo is public and the `ferrlabs-k8s` group sets `allows_public_repositories=false`.

**Why Fixtures**

The check context changes with this migration. A `uses:` job reports as `<caller job name> / <reusable job name>`, so `Conventional commits` becomes `PR title / Conventional commits`. That context is a required status check in 17 of the 20 repos, and migrating one of those without updating its ruleset in the same window blocks every PR there.

Fixtures is one of the three repos where the title check is not required, so nothing here can block, and this PR is its own measurement: the check name it reports is the name the other rulesets will have to require.

**What it buys**

The one-line `if: github.event.action != 'synchronize'` we just shipped took 20 PRs. The next change to this logic takes one.
