### PR TITLE
chore: probe the composed check name

### DIFF
--- a/.github/workflows/pr-title-probe.yml
+++ b/.github/workflows/pr-title-probe.yml
@@ -1,0 +1,12 @@
+name: PR title probe
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  title:
+    name: PR title
+    uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@f960ed3bbd48ad67062af348d864cd60f4da2f6e
+    with:
+      runner: ubuntu-latest

--- a/.github/workflows/pr-title-probe.yml
+++ b/.github/workflows/pr-title-probe.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  pull-requests: read
+
 jobs:
   title:
+    name: PR title
     uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@f960ed3bbd48ad67062af348d864cd60f4da2f6e
+    with:
+      runner: ubuntu-latest

--- a/.github/workflows/pr-title-probe.yml
+++ b/.github/workflows/pr-title-probe.yml
@@ -6,7 +6,4 @@ on:
 
 jobs:
   title:
-    name: PR title
     uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@f960ed3bbd48ad67062af348d864cd60f4da2f6e
-    with:
-      runner: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -287,3 +287,5 @@ Create branches from specific points and optionally merge them back:
 ## License
 
 [MPL-2.0](LICENSE)
+
+<!-- probe -->


### PR DESCRIPTION
Throwaway PR to read the check context the reusable produces now that the caller is on main. Closed without merging.