### PR TITLE
ci(pr-title): grant the caller permission and re-pin

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,9 +9,15 @@ on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, edited, reopened, synchronize]
 
+# Obligatoire : un workflow appelé ne peut que restreindre ce que l'appelant lui
+# donne. Sans ce bloc, le run finit en `startup_failure` et ne produit aucun
+# check run.
+permissions:
+  pull-requests: read
+
 jobs:
   title:
     name: PR title
-    uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@c0bc74da89ab88a5a5f138d94d8ac105536b2f5e # main
+    uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@64d3151ca65e6ec163a32db9497e66b1381fd20f # main
     with:
       runner: ubuntu-latest


### PR DESCRIPTION
Refs FerrLabs/.github#252

Completes the pilot started in #170. That version was missing the `permissions` block on the caller, so the run ended in `startup_failure`:

```
Error calling workflow 'FerrLabs/.github/.github/workflows/reusable-pr-title.yml@…'.
The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.
```

A called workflow can only narrow what the caller granted. Adds the block and re-pins to the fixed reusable (FerrLabs/.github#256).

Measured on a probe before this: the composed context is `PR title / Conventional commits`, and it reports `completed skipped` on a `synchronize`, so the skip works through the reusable too.