### PR TITLE
chore: normalise line endings to LF with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,40 @@
+# Every text file is LF, in the repository and on disk.
+#
+# Git already stores LF, so this does not rewrite history: it changes what a
+# checkout puts in the working tree. Without it, `core.autocrlf` hands Windows
+# CRLF while the formatters write LF, and `--check` runs then report nearly
+# every file as unformatted when nothing is actually wrong.
+* text=auto eol=lf
+
+# Declared binary so git never inspects or rewrites their bytes. The `text=auto`
+# heuristic already catches these by their NUL bytes, but a format that happens
+# to carry none in its first 8 KB would be corrupted silently, and images are
+# not worth that risk.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.avif binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.pdf binary
+*.mp3 binary
+*.wav binary
+*.ogg binary
+*.mp4 binary
+*.webm binary
+*.zip binary
+*.gz binary
+
+# The exception to the rule above: cmd.exe needs CRLF.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Kept from the previous file: both are already covered by the rule above,
+# and both are load-bearing enough to stay said out loud.
 .githooks/* text eol=lf
 *.sh text eol=lf


### PR DESCRIPTION
Part of FerrLabs/.github#263.

`* text=auto eol=lf`, binaries declared explicitly so their bytes are never inspected, and `.bat` / `.cmd` left at CRLF for cmd.exe.

## The diff is one file

Every text file in this repo is already LF in git's index, verified with `git ls-files --eol`: zero entries stored as CRLF. So nothing is renormalised and no content moves. The change is what a checkout puts on disk, not what is committed.

## What it fixes

With `core.autocrlf` on, a Windows checkout gets CRLF while the formatters in the toolchain write LF. Every `--check` run then reports files as unformatted purely because of their line endings. Measured on FerrGames-Cloud, where this landed first: 19 files failed `prettier --check` and running `prettier --write` over them produced an empty `git diff`. Not one had a real formatting problem.

The effect is that nobody trusts the check, so nobody runs it, so real drift accumulates unseen and no formatting gate can be added to CI.

`FerrLabs/ia` already carries this exact rule with the same reasoning, so this follows an existing precedent in the org rather than introducing a convention.

## Note for everyone's next pull

The first checkout after this merges rewrites line endings across the working tree once. It is local churn and changes no content.
